### PR TITLE
fix: only get http mirror

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 /.git*
 /action.yml
 /test/
+/tools/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,11 @@ jobs:
     steps:
       - name: Set up Git repository
         uses: actions/checkout@v1
+      
+      - name: Test shell scripts
+        run: |
+          sh test/sh/test.sh
+
       - name: Compile basic LaTeX document
         uses: ./
         with:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To enable `--shell-escape`, you should add it to `args`. For example, set `args`
 
 ### It fails to build the document, how to solve it?
 
-If this Github action fails to build the document, it is likely due to `texliveonfly` failing to install the missing packages. In this case, you can pass them explicitly in `extra_packages`. Try to find the missing packages or the missing fonts in the build log. You could also use `tlmgr search <keyword>` in your local environment to find the package. [Open an issue](https://github.com/xu-cheng/latex-action/issues/new) if you need help.
+If this Github action fails to build the document, it is likely due to `texliveonfly` failing to install the missing packages. In this case, you can pass them explicitly in `extra_packages`. Try to find the missing packages or the missing fonts in the build log. Alternatively, you could use the [`list_tl_pkgs.rb`](https://github.com/xu-cheng/latex-action/blob/master/tools/list_tl_pkgs.rb) script to list all the packages used by your LaTeX document. [Open an issue](https://github.com/xu-cheng/latex-action/issues/new) if you need help.
 
 ### Is it possible to change the TeXLive scheme?
 

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,7 @@ set -e
 echo "==> Install TeXLive"
 mkdir -p /tmp/install-tl
 cd /tmp/install-tl
-MIRROR_URL="$(wget -q -S -O /dev/null http://mirror.ctan.org/ 2>&1 | sed -ne 's/.*Location: \(\w*\)/\1/p')"
+MIRROR_URL="$(wget -q -S -O /dev/null http://mirror.ctan.org/ 2>&1 | sed -ne 's/.*Location: \(http\w*\)/\1/p')"
 wget -nv "${MIRROR_URL}systems/texlive/tlnet/install-tl-unx.tar.gz"
 wget -nv "${MIRROR_URL}systems/texlive/tlnet/install-tl-unx.tar.gz.sha512"
 wget -nv "${MIRROR_URL}systems/texlive/tlnet/install-tl-unx.tar.gz.sha512.asc"

--- a/test/sh/multiple-redirect.txt
+++ b/test/sh/multiple-redirect.txt
@@ -1,0 +1,21 @@
+  HTTP/1.1 302 Found
+  Date: Sun, 29 Sep 2019 11:16:02 GMT
+  Server: Apache/2.4.25 (Debian)
+  Location: http://mirrors.ibiblio.org/pub/mirrors/CTAN/
+  Content-Length: 309
+  Keep-Alive: timeout=5, max=100
+  Connection: Keep-Alive
+  Content-Type: text/html; charset=iso-8859-1
+  HTTP/1.1 301 Moved Permanently
+  Location: /CTAN/
+  Content-Length: 0
+  Date: Sun, 29 Sep 2019 11:16:02 GMT
+  Server: lighttpd/1.4.47
+  HTTP/1.1 200 OK
+  Content-Type: text/html
+  Accept-Ranges: bytes
+  ETag: "4102537645"
+  Last-Modified: Sat, 29 Oct 2016 08:46:26 GMT
+  Content-Length: 9189
+  Date: Sun, 29 Sep 2019 11:16:02 GMT
+  Server: lighttpd/1.4.47

--- a/test/sh/test.sh
+++ b/test/sh/test.sh
@@ -1,0 +1,12 @@
+pwd
+MIRROR_URL="$(cat test/sh/multiple-redirect.txt | sed -ne 's/.*Location: \(\w*\)/\1/p' | head -n 1)"
+EXPECTED='http://mirrors.ibiblio.org/pub/mirrors/CTAN/'
+
+if [ "${MIRROR_URL}" != "${EXPECTED}" ]; then
+    echo "TEST FAIL!"
+    echo "${MIRROR_URL}"
+    exit 1
+else
+    echo "TEST PASS."
+    exit 0
+fi

--- a/tools/list_tl_pkgs.rb
+++ b/tools/list_tl_pkgs.rb
@@ -1,0 +1,117 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "optparse"
+require "pathname"
+require "set"
+
+PREINST_PKGS = %w[
+  scheme-small
+  collection-fontsrecommended
+  biblatex
+].freeze
+
+def error(msg)
+  if $stderr.tty?
+    pre = "\033[31m"
+    post = "\033[0m"
+  end
+  abort "#{pre}Error#{post}: #{msg}"
+end
+
+def locate_texmfdist
+  cmd = %w[kpsewhich -var-value=TEXMFDIST]
+  output, _status = Open3.capture2(*cmd)
+  output.strip
+rescue StandardError => e
+  error "Fail to execute `#{cmd.join " "}`\n#{e.message}"
+end
+
+def read_tlpdb
+  cmd = %w[tlmgr dump-tlpdb --json --local]
+  output, _status = Open3.capture2(*cmd)
+  JSON.parse output
+rescue StandardError => e
+  error "Fail to execute `#{cmd.join " "}`\n#{e.message}"
+end
+
+def build_mapping(db)
+  file_pkg_mapping = {}
+  pkg_deps_mapping = {}
+  db["main"]["tlpkgs"].each do |pkg|
+    name = pkg["name"]
+    pkg["runfiles"].each do |file|
+      file_pkg_mapping[file] = name
+    end
+    pkg_deps_mapping[name] = pkg["depends"]
+  end
+  [file_pkg_mapping, pkg_deps_mapping]
+end
+
+def list_preinst_pkgs(pkg_deps_mapping)
+  all_pkgs = Set.new
+  pkgs = Set.new(PREINST_PKGS)
+  until pkgs.empty?
+    all_pkgs |= pkgs
+    pkgs = Set.new(pkgs.flat_map { |pkg| pkg_deps_mapping[pkg] }.compact)
+  end
+  all_pkgs
+end
+
+if $PROGRAM_NAME == __FILE__
+  subtract_preinst = true
+  parser = OptionParser.new do |opts|
+    opts.banner = <<~BANNER
+      Usage: #{$PROGRAM_NAME} [options] <root_file>
+
+      List all texlive packages used by a document.
+
+      Arguments:
+          <root_file>                      Path to the root TeX file
+    BANNER
+
+    opts.separator ""
+    opts.separator "Options:"
+    opts.on("--list-all", "Include preinstalled packages in Github Action") do
+      subtract_preinst = false
+    end
+    opts.on("-h", "--help", "Show this message") do
+      puts opts.help
+      exit
+    end
+  end
+  parser.parse!
+
+  abort parser.help if ARGV.size != 1
+  root_file = Pathname.new ARGV[0]
+  fls_file = root_file.parent / "#{root_file.basename ".*"}.fls"
+
+  unless fls_file.file?
+    error <<~ERROR
+      Cannot find the file <#{fls_file}>.
+      Please compile the document using latexmk.
+    ERROR
+  end
+
+  db = read_tlpdb
+  file_pkg_mapping, pkg_deps_mapping = build_mapping db
+  texmfdist = locate_texmfdist
+  texmfdist_parent = "#{File.dirname texmfdist}/"
+
+  pkgs = Set.new
+  fls_file.readlines.each do |line|
+    next unless line.start_with? "INPUT"
+
+    input_file = line.strip.rpartition(" ").last
+
+    next unless input_file.start_with? texmfdist
+
+    pkgs << file_pkg_mapping[input_file.sub texmfdist_parent, ""]
+  end
+
+  preinst_pkgs = list_preinst_pkgs pkg_deps_mapping
+  pkgs.subtract(preinst_pkgs) if subtract_preinst
+  puts pkgs.to_a.sort.join(" ")
+end


### PR DESCRIPTION
During my testing on this `setup.sh`, I found sometimes the mirror request gives these output:
```
  HTTP/1.1 302 Found
  Date: Sun, 29 Sep 2019 11:16:02 GMT
  Server: Apache/2.4.25 (Debian)
  Location: http://mirrors.ibiblio.org/pub/mirrors/CTAN/
  Content-Length: 309
  Keep-Alive: timeout=5, max=100
  Connection: Keep-Alive
  Content-Type: text/html; charset=iso-8859-1
  HTTP/1.1 301 Moved Permanently
  Location: /CTAN/
  Content-Length: 0
  Date: Sun, 29 Sep 2019 11:16:02 GMT
  Server: lighttpd/1.4.47
  HTTP/1.1 200 OK
  Content-Type: text/html
  Accept-Ranges: bytes
  ETag: "4102537645"
  Last-Modified: Sat, 29 Oct 2016 08:46:26 GMT
  Content-Length: 9189
  Date: Sun, 29 Sep 2019 11:16:02 GMT
  Server: lighttpd/1.4.47
```

which will fail the setting up script because that response gives 2 `Location` records. The 2nd one is a relative path, which should be excluded.