### PR TITLE
Version pin Docker FROM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM xucheng/texlive-full:latest
+# SHA hash is from Docker tag 20191201
+FROM xucheng/texlive-full@sha256:85a768164d545a2947316554e0139367d6c6119df7982a953e05d58a62cc87c9
 
 COPY \
   LICENSE \


### PR DESCRIPTION
Using SHA hash as they are immutable.  Best to version pin everything where possible.