### PR TITLE
Create working directory if it does not exist

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -94,6 +94,9 @@ if [[ -n "$extra_packages" ]]; then
 fi
 
 if [[ -n "$working_directory" ]]; then
+  if [[ ! -d "$working_directory" ]]; then
+    mkdir -p "$working_directory"
+  fi
   cd "$working_directory"
 fi
 


### PR DESCRIPTION
I had the need for using a build folder which I assumed the action would automatically create for me if inexistent but the action stopped and failed. So that is why I propose these changes for similar situations.

If these changes are deemed undesirable, maybe adding an `output_directory` parameter to the action which should be passed to the TeX compiler would be a good solution and nice addition?