### PR TITLE
Updated README example for pre_compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ If you want to run arbitrary commands in a TeXLive environment, use [texlive-act
 
 ## Inputs
 
+Each input is provided as a key inside the `with` section of the action.
+
 * `root_file`
 
     The root LaTeX file to be compiled. This input is required. You can also pass multiple files as a multi-line string to compile multiple documents. For example:
@@ -39,7 +41,7 @@ If you want to run arbitrary commands in a TeXLive environment, use [texlive-act
 
 * `pre_compile`
 
-    Arbitrary bash codes to be executed before compiling LaTeX documents. For example, `pre_compile: "tlmgr update --all"` to update all TeXLive packages.
+    Arbitrary bash codes to be executed before compiling LaTeX documents. For example, `pre_compile: "tlmgr update --self && tlmgr update --all"` to update all TeXLive packages.
 
 * `post_compile`
 
@@ -112,7 +114,7 @@ To enable `--shell-escape`, set the `latexmk_shell_escape` input.
 ### Where is the PDF file? How to upload it?
 
 The PDF file will be in the same folder as that of the LaTeX source in the CI environment. It is up to you on whether to upload it to some places. Here are some example.
-* You can use [`@actions/upload-artifact`](https://github.com/actions/upload-artifact) to upload PDF file to the workflow tab. For example you can add
+* You can use [`@actions/upload-artifact`](https://github.com/actions/upload-artifact) to upload a zip containing the PDF  file to the workflow tab. For example you can add
 
   ```yaml
   - uses: actions/upload-artifact@v2
@@ -120,6 +122,8 @@ The PDF file will be in the same folder as that of the LaTeX source in the CI en
       name: PDF
       path: main.pdf
   ```
+  
+... which will result in a `PDF.zip` being uploaded with `main.pdf` contained inside.
 
 * You can use [`@softprops/action-gh-release`](https://github.com/softprops/action-gh-release) to upload PDF file to the Github Release.
 * You can use normal shell tools such as `scp`/`git`/`rsync` to upload PDF file anywhere. For example, you can git push to the `gh-pages` branch in your repo, so you can view the document using Github Pages.


### PR DESCRIPTION
It appears that if tlmgr is not up-to-date, the example of updating any dependencies in the README will fail immediately.

Running tlmgr update --self first remediates this issue, so I have updated that example

I also amended the description for the `upload artifact` part slightly.