### PR TITLE
Introduce PDFLaTeX Support and Complex Compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ By default, this action uses pdfLaTeX. If you want to use XeLaTeX or LuaLaTeX, y
     root_file: main.tex
     latexmk_use_lualatex: true
 ```
+```yaml
+- uses: xu-cheng/latex-action@v2
+  with:
+    root_file: main.tex
+    latexmk_use_pdflatex: true
+```
+
 
 Alternatively, you could create a `.latexmkrc` file. Refer to the [`latexmk` document](http://texdoc.net/texmf-dist/doc/support/latexmk/latexmk.pdf) for more information.
 
@@ -139,6 +146,18 @@ The PDF file will be in the same folder as that of the LaTeX source in the CI en
   ```
 
   It will result in a `PDF.zip` being uploaded with `main.pdf` contained inside.
+
+* Or you can use wildcard to upload a zip containing all PDF file to the workflow tab. For example you can add
+
+  ```yaml
+  - uses: actions/upload-artifact@v2
+    with:
+      name: PDF
+      path: '*.pdf'
+  ```
+
+  It will result in a `PDF.zip` being uploaded with `main.pdf` contained inside.
+
 
 * You can use [`@softprops/action-gh-release`](https://github.com/softprops/action-gh-release) to upload PDF file to the Github Release.
 * You can use normal shell tools such as `scp`/`git`/`rsync` to upload PDF file anywhere. For example, you can git push to the `gh-pages` branch in your repo, so you can view the document using Github Pages.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ Each input is provided as a key inside the `with` section of the action.
 
     Instruct `latexmk` to use XeLaTeX.
 
+* `latexmk_use_pdflatex`
+
+    Instruct `latexmk` to use PDFLaTeX.
+
+
 ## Example
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # latex-action
 
-[![GitHub Actions Status](https://github.com/xu-cheng/latex-action/workflows/Test%20Github%20Action/badge.svg)](https://github.com/xu-cheng/latex-action/actions)
+[![GitHub Actions Status](https://github.com/xu-cheng/latex-action/workflows/Test%20GitHub%20Action/badge.svg)](https://github.com/xu-cheng/latex-action/actions)
 
 GitHub Action to compile LaTeX documents.
 
@@ -159,8 +159,8 @@ The PDF file will be in the same folder as that of the LaTeX source in the CI en
   It will result in a `PDF.zip` being uploaded with `main.pdf` contained inside.
 
 
-* You can use [`@softprops/action-gh-release`](https://github.com/softprops/action-gh-release) to upload PDF file to the Github Release.
-* You can use normal shell tools such as `scp`/`git`/`rsync` to upload PDF file anywhere. For example, you can git push to the `gh-pages` branch in your repo, so you can view the document using Github Pages.
+* You can use [`@softprops/action-gh-release`](https://github.com/softprops/action-gh-release) to upload PDF file to the GitHub Release.
+* You can use normal shell tools such as `scp`/`git`/`rsync` to upload PDF file anywhere. For example, you can git push to the `gh-pages` branch in your repo, so you can view the document using GitHub Pages.
 
 ### How to add additional paths to the LaTeX input search path?
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # latex-action
 
-[![GitHub Actions Status](https://github.com/xu-cheng/latex-action/workflows/Test%20GitHub%20Action/badge.svg)](https://github.com/xu-cheng/latex-action/actions)
+[![GitHub Actions Status](https://github.com/xu-cheng/latex-action/workflows/Test%20Github%20Action/badge.svg)](https://github.com/xu-cheng/latex-action/actions)
 
 GitHub Action to compile LaTeX documents.
 
@@ -194,6 +194,24 @@ This is an upstream issue where `xindy.x86_64-linuxmusl` is currently missing in
 * [Open an issue](https://github.com/xu-cheng/latex-action/issues/new) if you need help. Please include a [minimal working example][mwe] to demonstrate your problem.
 
 [mwe]: https://tex.meta.stackexchange.com/questions/228/ive-just-been-asked-to-write-a-minimal-working-example-mwe-what-is-that
+
+### How to compile reference by bibtex or complex compile?
+
++ First of all, you should specify the compiler in `PDFLaTeX` or `LuaLaTeX` or `XeLaTeX` or keep it blank to use default.
++ Set `use_bibtex` to `true`
+
+```yaml
+- uses: xu-cheng/latex-action@v2
+  with:
+    root_file: main.tex
+    latexmk_use_xelatex: true
+    use_bibtex: true
+```
+
++ If you use snippet above, it will follow the path below.
++ XeLaTeX -> BibTeX -> XeLaTeX -> XeLaTeX
+
+
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,8 @@ inputs:
     description: Instruct latexmk to use LuaLaTeX
   latexmk_use_xelatex:
     description: Instruct latexmk to use XeLaTeX
+  latexmk_use_pdflatex:
+    description: Instruct latexmk to use PDFLaTeX
 runs:
   using: docker
   image: Dockerfile

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,8 @@ inputs:
     description: Instruct latexmk to use XeLaTeX
   latexmk_use_pdflatex:
     description: Instruct latexmk to use PDFLaTeX
+  use_bibtex:
+    description: Use BibTeX to compile reference (Complex Compile)
 runs:
   using: docker
   image: Dockerfile
@@ -47,6 +49,7 @@ runs:
     - ${{ inputs.latexmk_shell_escape }}
     - ${{ inputs.latexmk_use_lualatex }}
     - ${{ inputs.latexmk_use_xelatex }}
+    - ${{ inputs.use_bibtex }}
 branding:
   icon: book
   color: blue

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,6 +28,7 @@ latexmk_shell_escape="${10}"
 latexmk_use_lualatex="${11}"
 latexmk_use_xelatex="${12}"
 latexmk_use_pdflatex="${13}"
+use_bibtex="${14}"
 
 if [[ -z "$root_file" ]]; then
   error "Input 'root_file' is missing."
@@ -140,7 +141,15 @@ for f in "${root_file[@]}"; do
     error "File '$f' cannot be found from the directory '$PWD'."
   fi
 
-  "$compiler" "${args[@]}" "$f"
+  if [[ -n "$use_bibtex" ]]; then
+    "$compiler" "${args[@]}" "$f"
+    bibtex "$f"
+    "$compiler" "${args[@]}" "$f"
+    "$compiler" "${args[@]}" "$f"
+  else
+    "$compiler" "${args[@]}" "$f"
+  fi
+
 done
 
 if [[ -n "$post_compile" ]]; then


### PR DESCRIPTION
I've introduce two changes below:
+ PDFLaTeX is currently the dominant compiler for some publishers. But unless specified, by default latexmk won't use PDFLaTeX.
+ And we now can use complex compile (PDFLaTeX -> BibTeX -> PDFLaTeX -> PDFLaTeX) easily.