### PR TITLE
Introduce extra_fonts to GitHub Action script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,18 @@ jobs:
           working_directory: test/
           compiler: arara
           args: "--verbose"
+      - name: Compile LaTeX document with extra_fonts and XeLaTeX
+        uses: ./
+        with:
+          root_file: extra_fonts.tex
+          working_directory: test/
+          pre_compile: |
+            apk add p7zip wget --no-cache
+            mkdir -p ./test/fonts/
+            wget https://github.com/be5invis/Sarasa-Gothic/releases/download/v0.34.7/sarasa-gothic-ttf-0.34.7.7z
+            7z e sarasa-gothic-ttf-0.34.7.7z -r -ofonts/
+          latexmk_use_xelatex: true
+          extra_fonts: "./fonts"
       # https://github.com/xu-cheng/latex-action/issues/16
       - name: Test Action with Github Default Template
         uses: ./
@@ -104,9 +116,12 @@ jobs:
           file test/minted.pdf | grep -q ' PDF '
           file test/graphviz.pdf | grep -q ' PDF '
           file test/abc.pdf | grep -q ' PDF '
+          file test/extra_fonts.pdf | grep -q ' PDF '
       - name: Upload
         uses: actions/upload-artifact@master
         with:
           name: test
-          path: test
+          path: |
+            test/*.pdf
+            test/*.log
         if: always()

--- a/action.yml
+++ b/action.yml
@@ -7,42 +7,30 @@ inputs:
     required: true
   glob_root_file:
     description: Interpret the root_file input as bash glob pattern
-    required: true
   working_directory:
     description: The working directory for this action
-    required: false
   compiler:
     description: The LaTeX engine to be invoked
     default: latexmk
-    required: true
   args:
     description: Extra arguments to be passed to the LaTeX engine
     default: "-pdf -file-line-error -halt-on-error -interaction=nonstopmode"
-    required: true
   extra_packages:
     description: "[Deprecated] Install extra packages by tlmgr"
-    required: false
   extra_system_packages:
     description: Install extra packages by apk
-    required: false
+  extra_fonts:
+    description: Add extra fonts by fontconfig. It supports glob patterns.
   pre_compile:
     description: Arbitrary bash codes to be executed before compiling LaTeX documents
-    required: false
   post_compile:
     description: Arbitrary bash codes to be executed after compiling LaTeX documents
-    required: false
   latexmk_shell_escape:
     description: Instruct latexmk to enable --shell-escape
-    required: false
   latexmk_use_lualatex:
     description: Instruct latexmk to use LuaLaTeX
-    required: false
   latexmk_use_xelatex:
     description: Instruct latexmk to use XeLaTeX
-    required: false
-  custom_font_dir:
-    description: Your custom font directory
-    required: false
 runs:
   using: docker
   image: Dockerfile
@@ -59,7 +47,7 @@ runs:
     - ${{ inputs.latexmk_shell_escape }}
     - ${{ inputs.latexmk_use_lualatex }}
     - ${{ inputs.latexmk_use_xelatex }}
-    - ${{ inputs.custom_font_dir }}
+    - ${{ inputs.extra_fonts }}
 branding:
   icon: book
   color: blue

--- a/action.yml
+++ b/action.yml
@@ -7,28 +7,42 @@ inputs:
     required: true
   glob_root_file:
     description: Interpret the root_file input as bash glob pattern
+    required: true
   working_directory:
     description: The working directory for this action
+    required: false
   compiler:
     description: The LaTeX engine to be invoked
     default: latexmk
+    required: true
   args:
     description: Extra arguments to be passed to the LaTeX engine
     default: "-pdf -file-line-error -halt-on-error -interaction=nonstopmode"
+    required: true
   extra_packages:
     description: "[Deprecated] Install extra packages by tlmgr"
+    required: false
   extra_system_packages:
     description: Install extra packages by apk
+    required: false
   pre_compile:
     description: Arbitrary bash codes to be executed before compiling LaTeX documents
+    required: false
   post_compile:
     description: Arbitrary bash codes to be executed after compiling LaTeX documents
+    required: false
   latexmk_shell_escape:
     description: Instruct latexmk to enable --shell-escape
+    required: false
   latexmk_use_lualatex:
     description: Instruct latexmk to use LuaLaTeX
+    required: false
   latexmk_use_xelatex:
     description: Instruct latexmk to use XeLaTeX
+    required: false
+  custom_font_dir:
+    description: Your custom font directory
+    required: false
 runs:
   using: docker
   image: Dockerfile
@@ -45,6 +59,7 @@ runs:
     - ${{ inputs.latexmk_shell_escape }}
     - ${{ inputs.latexmk_use_lualatex }}
     - ${{ inputs.latexmk_use_xelatex }}
+    - ${{ inputs.custom_font_dir }}
 branding:
   icon: book
   color: blue

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,12 +27,18 @@ post_compile="${9}"
 latexmk_shell_escape="${10}"
 latexmk_use_lualatex="${11}"
 latexmk_use_xelatex="${12}"
+custom_font_dir="${13}"
+
+if [[ -n "$custom_font_dir" ]]; then
+  cp $custom_font_dir/* /usr/share/fonts
+  mkfontscale && mkfontdir && fc-cache -fv
+fi
 
 if [[ -z "$root_file" ]]; then
   error "Input 'root_file' is missing."
 fi
 
-readarray -t root_file <<< "$root_file"
+readarray -t root_file <<<"$root_file"
 
 if [[ -n "$working_directory" ]]; then
   if [[ ! -d "$working_directory" ]]; then
@@ -42,13 +48,13 @@ if [[ -n "$working_directory" ]]; then
 fi
 
 if [[ -n "$glob_root_file" ]]; then
-    expanded_root_file=()
-    for pattern in "${root_file[@]}"; do
-      expanded="$(compgen -G "$pattern" || echo "$pattern")"
-      readarray -t files <<< "$expanded"
-      expanded_root_file+=("${files[@]}")
-    done
-    root_file=("${expanded_root_file[@]}")
+  expanded_root_file=()
+  for pattern in "${root_file[@]}"; do
+    expanded="$(compgen -G "$pattern" || echo "$pattern")"
+    readarray -t files <<<"$expanded"
+    expanded_root_file+=("${files[@]}")
+  done
+  root_file=("${expanded_root_file[@]}")
 fi
 
 if [[ -z "$compiler" && -z "$args" ]]; then
@@ -57,7 +63,7 @@ if [[ -z "$compiler" && -z "$args" ]]; then
   args="-pdf -file-line-error -halt-on-error -interaction=nonstopmode"
 fi
 
-IFS=' ' read -r -a args <<< "$args"
+IFS=' ' read -r -a args <<<"$args"
 
 if [[ "$compiler" = "latexmk" ]]; then
   if [[ -n "$latexmk_shell_escape" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,18 +27,32 @@ post_compile="${9}"
 latexmk_shell_escape="${10}"
 latexmk_use_lualatex="${11}"
 latexmk_use_xelatex="${12}"
-custom_font_dir="${13}"
-
-if [[ -n "$custom_font_dir" ]]; then
-  cp $custom_font_dir/* /usr/share/fonts
-  mkfontscale && mkfontdir && fc-cache -fv
-fi
+extra_fonts="${13}"
 
 if [[ -z "$root_file" ]]; then
   error "Input 'root_file' is missing."
 fi
 
-readarray -t root_file <<<"$root_file"
+readarray -t root_file <<< "$root_file"
+
+if [[ -n "$extra_fonts" ]]; then
+  # apk --no-cache add fontconfig
+  readarray -t extra_fonts <<< "$extra_fonts"
+  for f in "${extra_fonts[@]}"; do
+  if [[ -z "$f" ]]; then
+    continue
+  fi
+
+  info "Copying $f"
+
+  if [[ ! -f "$f" ]]; then
+    error "File '$f' cannot be found from the directory '$PWD'."
+  fi
+
+  "cp" "-r" "$f" "/usr/share/fonts"
+  done
+  fc-cache -fv
+fi
 
 if [[ -n "$working_directory" ]]; then
   if [[ ! -d "$working_directory" ]]; then
@@ -48,13 +62,13 @@ if [[ -n "$working_directory" ]]; then
 fi
 
 if [[ -n "$glob_root_file" ]]; then
-  expanded_root_file=()
-  for pattern in "${root_file[@]}"; do
-    expanded="$(compgen -G "$pattern" || echo "$pattern")"
-    readarray -t files <<<"$expanded"
-    expanded_root_file+=("${files[@]}")
-  done
-  root_file=("${expanded_root_file[@]}")
+    expanded_root_file=()
+    for pattern in "${root_file[@]}"; do
+      expanded="$(compgen -G "$pattern" || echo "$pattern")"
+      readarray -t files <<< "$expanded"
+      expanded_root_file+=("${files[@]}")
+    done
+    root_file=("${expanded_root_file[@]}")
 fi
 
 if [[ -z "$compiler" && -z "$args" ]]; then
@@ -63,7 +77,7 @@ if [[ -z "$compiler" && -z "$args" ]]; then
   args="-pdf -file-line-error -halt-on-error -interaction=nonstopmode"
 fi
 
-IFS=' ' read -r -a args <<<"$args"
+IFS=' ' read -r -a args <<< "$args"
 
 if [[ "$compiler" = "latexmk" ]]; then
   if [[ -n "$latexmk_shell_escape" ]]; then

--- a/test/extra_fonts.tex
+++ b/test/extra_fonts.tex
@@ -1,0 +1,57 @@
+\documentclass{article}
+\usepackage{fontspec, xunicode, xltxtra}
+\usepackage{xeCJK}
+\usepackage{listings}
+
+\usepackage{xcolor}
+\definecolor{dkgreen}{rgb}{0,0.6,0}
+\definecolor{gray}{rgb}{0.5,0.5,0.5}
+\definecolor{mauve}{rgb}{0.58,0,0.82}
+
+\setCJKfamilyfont{SMSC}{Sarasa Mono Slab SC}
+\newfontfamily\sgg{Sarasa Mono Slab SC}
+\newcommand{\sg}{\CJKfamily{SMSC}}
+
+\begin{document}
+
+\lstset{
+    language=C++,
+    basicstyle=\small\sg\sgg,
+    columns=fullflexible,
+    backgroundcolor=\color[rgb]{0.96,0.96,0.96},
+    extendedchars=false,
+    breakatwhitespace=true,
+    breaklines=true,
+    captionpos=b,
+    numbers=left,
+    numbersep=10pt,
+    showspaces=false,
+    showstringspaces=false,
+    showtabs=false,
+    stepnumber=1,
+    rulecolor=\color{black},
+    tabsize=4,
+    texcl=true,
+    frame=trBL,
+    sensitive=true,
+    frameround=fttt,
+    mathescape=false,
+    xleftmargin=3em,
+    xrightmargin=3em,
+    keywordstyle=\bfseries\color{blue},
+    commentstyle=\color{dkgreen},
+    stringstyle=\color{mauve}
+}
+
+\begin{lstlisting}
+#include <iostream>
+
+using namespace std;
+
+int main() {
+    cout << "Hello, 世界" << endl;
+    return 0;
+}
+\end{lstlisting}
+
+\end{document}


### PR DESCRIPTION
I've tested this action and now it can support specific custom font directory. In this screenshot, I use `Sarasa Gothic` to render code.

![](https://user-images.githubusercontent.com/78157415/137669336-56559712-96d8-4a2c-86ca-8f71eda280d2.png)

In this PR, I just modify the action file. It works only when [latex-docker/#11](https://github.com/xu-cheng/latex-docker/pull/11) is merged.

Refer to #74 