### PR TITLE
feat: add `work_in_corresponding_directories` option to compile in different directories where the root LaTeX files located

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,8 @@ inputs:
     description: Instruct latexmk to use LuaLaTeX
   latexmk_use_xelatex:
     description: Instruct latexmk to use XeLaTeX
+  work_in_corresponding_directories:
+    description: Use the directory where each root LaTex file is located as the working directory
 runs:
   using: docker
   image: Dockerfile
@@ -48,6 +50,7 @@ runs:
     - ${{ inputs.latexmk_shell_escape }}
     - ${{ inputs.latexmk_use_lualatex }}
     - ${{ inputs.latexmk_use_xelatex }}
+    - ${{ inputs.work_in_corresponding_directories }}
 branding:
   icon: book
   color: blue

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,8 +64,8 @@ if [[ -n "$work_in_corresponding_directories" ]]; then
   real_root_file_filename=()
   for file in "${root_file[@]}"; do
     real="$(realpath "$file")"
-    real_root_file_directory+="$(dirname "$real")"
-    real_root_file_filename+="$(basename "$real")"
+    real_root_file_directory+=("$(dirname "$real")")
+    real_root_file_filename+=("$(basename "$real")")
   done
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,9 +36,15 @@ fi
 
 readarray -t root_file <<< "$root_file"
 
-if [[ -n "$working_directory" && -z "$work_in_corresponding_directories" ]]; then
+if [[ -n "$working_directory"]]; then
   if [[ ! -d "$working_directory" ]]; then
     mkdir -p "$working_directory"
+  fi
+  if [[ -n "$work_in_corresponding_directories" ]] then
+    real_working_directory="$(realpath "$working_directory")"
+    info "Enter $real_working_directory"
+  else
+    info "Enter $working_directory"
   fi
   cd "$working_directory"
 fi
@@ -169,18 +175,19 @@ if [[ -z "work_in_corresponding_directories" ]]; then
     "$compiler" "${args[@]}" "$f"
   done
 else
-  for (( i = 0; i < ${#real_root_file_directory[*]}; ++i )); do
+  for (( i=0; i<${#real_root_file_directory[*]}; ++i )); do
     info "Enter ${real_root_file_directory[$i]}"
-    
     cd "${real_root_file_directory[$i]}"
-
     info "Compile ${real_root_file_filename[$i]}"
-
     "$compiler" "${args[@]}" "${real_root_file_filename[$i]}"
   done
 fi
 
 if [[ -n "$post_compile" ]]; then
+  if [[ -n "$work_in_corresponding_directories" ]] then
+    info "Enter $real_working_directory"
+    cd "$real_working_directory"
+  fi
   info "Run post compile commands"
   eval "$post_compile"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ post_compile="${10}"
 latexmk_shell_escape="${11}"
 latexmk_use_lualatex="${12}"
 latexmk_use_xelatex="${13}"
-work_in_corresponding_directories=${14}
+work_in_corresponding_directories="${14}"
 
 if [[ -z "$root_file" ]]; then
   error "Input 'root_file' is missing."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,7 @@ fi
 
 readarray -t root_file <<< "$root_file"
 
-if [[ -n "$working_directory"]]; then
+if [[ -n "$working_directory" ]]; then
   if [[ ! -d "$working_directory" ]]; then
     mkdir -p "$working_directory"
   fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,7 +40,7 @@ if [[ -n "$working_directory"]]; then
   if [[ ! -d "$working_directory" ]]; then
     mkdir -p "$working_directory"
   fi
-  if [[ -n "$work_in_corresponding_directories" ]] then
+  if [[ -n "$work_in_corresponding_directories" ]]; then
     real_working_directory="$(realpath "$working_directory")"
     info "Enter $real_working_directory"
   else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -184,7 +184,7 @@ else
 fi
 
 if [[ -n "$post_compile" ]]; then
-  if [[ -n "$work_in_corresponding_directories" ]] then
+  if [[ -n "$work_in_corresponding_directories" ]]; then
     info "Enter $real_working_directory"
     cd "$real_working_directory"
   fi


### PR DESCRIPTION
I have been facing with the situation that there are more than one LaTeX files stored in different directories in a repo and each file relies on different figures which are located relatively. For example:

```
.
├── article1
│   ├── art1.tex  # uses \includegraphics{figures/fig1.png}
│   └── figures
│       └── fig1.png
└── article2
    ├── art2.tex  # uses \includegraphics{figures/fig2.png}
    └── figures
        └── fig2.png
```

Although these LaTeX files can be selected at once using globs or compiled separately, there's currently no way of compiling all these files correctly in one GitHub Action step. Simply specifying a working directory isn't helpful in resolving different relative paths from different bases and this could be a common issue among repos that has various separate LaTeX files.

This pr brings about a new option named `work_in_corresponding_directories` to compile each root LaTex file in the directory where it is located. After enabling this option, the working directory specified will be used as the base directory for resolving globs and the compilation will take place in the corresponding directories of the resolved root LaTeX files.

Besides, this pr has a new feature that logs `Enter <directory>` before executing `cd <directory>` to help with debugging.
