### PR TITLE
feat: compile multiple files with multitasking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,29 @@ jobs:
           glob_root_file: true
           working_directory: test/
           work_in_root_file_dir: true
+      - name: Compile multiple LaTeX documents without multitasking
+        uses: ./
+        with:
+          root_file: |
+            file1.tex
+            file2.tex
+            glob_test*.tex
+            subdir*/main.tex
+          glob_root_file: true
+          working_directory: test/
+          work_in_root_file_dir: true
+      - name: Compile multiple LaTeX documents with multitasking
+        uses: ./
+        with:
+          root_file: |
+            file1.tex
+            file2.tex
+            glob_test*.tex
+            subdir*/main.tex
+          glob_root_file: true
+          working_directory: test/
+          work_in_root_file_dir: true
+          multitask: true
       - name: Compile LaTeX document with math symbols
         uses: ./
         with:

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,8 @@ inputs:
     description: Instruct latexmk to use LuaLaTeX
   latexmk_use_xelatex:
     description: Instruct latexmk to use XeLaTeX
+  multitask:
+    description: Compile multiple latex files simultaneously according to the cpu core count
 runs:
   using: docker
   image: Dockerfile
@@ -51,6 +53,7 @@ runs:
     - ${{ inputs.latexmk_shell_escape }}
     - ${{ inputs.latexmk_use_lualatex }}
     - ${{ inputs.latexmk_use_xelatex }}
+    - ${{ inputs.multitask }}
 branding:
   icon: book
   color: blue

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -154,7 +154,7 @@ for f in "${root_file[@]}"; do
     continue
   fi
 
-  if [[ -n "$multitask" && "jobs -r | wc -l" -ge "$cpu_count" ]]; then
+  if [[ -n "$multitask" && "$(jobs -r | wc -l)" -ge "$cpu_count" ]]; then
     wait -n
   fi
 


### PR DESCRIPTION
This pr provides an option `multitask` to compile multiple latex files simultaneously according to the cpu core count.

After enabling this option, the speed of compiling in one of my repos has boosted to roughly 1.5x (on a 2-core GitHub hosted runner).