### PR TITLE
change mode of arara

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test Github Action
+name: Test GitHub Action
 on:
   push:
   pull_request:
@@ -86,7 +86,7 @@ jobs:
           compiler: arara
           args: "--verbose"
       # https://github.com/xu-cheng/latex-action/issues/16
-      - name: Test Action with Github Default Template
+      - name: Test Action with GitHub Default Template
         uses: ./
         with:
           # The root LaTeX file to be compiled

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,6 @@ COPY \
   entrypoint.sh \
   /root/
 
+RUN chmod +x /opt/texlive/texdir/texmf-dist/scripts/arara/arara.sh
+
 ENTRYPOINT ["/root/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # latex-action
 
-[![GitHub Actions Status](https://github.com/xu-cheng/latex-action/workflows/Test%20Github%20Action/badge.svg)](https://github.com/xu-cheng/latex-action/actions)
+[![GitHub Actions Status](https://github.com/xu-cheng/latex-action/workflows/Test%20GitHub%20Action/badge.svg)](https://github.com/xu-cheng/latex-action/actions)
 
 GitHub Action to compile LaTeX documents.
 
@@ -151,8 +151,8 @@ The PDF file will be in the same folder as that of the LaTeX source in the CI en
 
   It will result in a `PDF.zip` being uploaded with `main.pdf` contained inside.
 
-* You can use [`@softprops/action-gh-release`](https://github.com/softprops/action-gh-release) to upload PDF file to the Github Release.
-* You can use normal shell tools such as `scp`/`git`/`rsync` to upload PDF file anywhere. For example, you can git push to the `gh-pages` branch in your repo, so you can view the document using Github Pages.
+* You can use [`@softprops/action-gh-release`](https://github.com/softprops/action-gh-release) to upload PDF file to the GitHub Release.
+* You can use normal shell tools such as `scp`/`git`/`rsync` to upload PDF file anywhere. For example, you can git push to the `gh-pages` branch in your repo, so you can view the document using GitHub Pages.
 
 ### How to add additional paths to the LaTeX input search path?
 

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: Github Action for LaTeX
+name: GitHub Action for LaTeX
 description: GitHub Action to compile LaTeX documents
 author: Cheng XU
 inputs:


### PR DESCRIPTION
Resolves #89 

Before

```shell
bash-5.1# arara --version
bash: /opt/texlive/texdir/bin/x86_64-linuxmusl/arara: Permission denied
```

After

```shell
bash-5.1# chmod +x /opt/texlive/texdir/texmf-dist/scripts/arara/arara.sh
bash-5.1# arara --version
  __ _ _ __ __ _ _ __ __ _
 / _` | '__/ _` | '__/ _` |
| (_| | | | (_| | | | (_| |
 \__,_|_|  \__,_|_|  \__,_|

arara 6.1.6
Copyright (c) 2022, Island of TeX
arara is released under the New BSD license.

New features in version 6.1.6:
* Split arara into API, core and implementation packages.
* Refactored localization to use IETF BCP 47 codes.
* Added quite a number of rules and improved syntax.
* Rules now have a unique file name to be identifiable in a texmf tree.
* New ability to specify default preamble for files without directives.
* Added safe mode for disabling easily exploitable features.
* Removed arara shorthands (<arara>).
* Multiple bug fixes (exit codes, currentFile handling, ...)

See the full changelog of this release at
https://gitlab.com/islandoftex/arara/-/blob/development/CHANGELOG.md
```