### PR TITLE
Implement continue_on_error option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,12 @@ jobs:
           working_directory: test/
           compiler: arara
           args: "--verbose"
+      - name: Compile LaTeX document with errors using continue_on_error
+        uses: ./
+        with:
+          root_file: error.tex
+          working_directory: test/
+          continue_on_error: true
       # https://github.com/xu-cheng/latex-action/issues/16
       - name: Test Action with Github Default Template
         uses: ./
@@ -109,7 +115,7 @@ jobs:
           # The LaTeX engine to be invoked
           compiler: # optional, default is latexmk
           # Extra arguments to be passed to the LaTeX engine
-          args: # optional, default is -pdf -file-line-error -halt-on-error -interaction=nonstopmode
+          args: # optional, default is -pdf -file-line-error -interaction=nonstopmode
           # [Deprecated] Install extra packages by tlmgr
           extra_packages: # optional
           # Install extra packages by apk
@@ -118,6 +124,8 @@ jobs:
           pre_compile: # optional
           # Arbitrary bash codes to be executed after compiling LaTeX documents
           post_compile: # optional
+          # Ignore LaTeX build errors
+          continue_on_error: # optional, default false
           # Instruct latexmk to enable --shell-escape
           latexmk_shell_escape: # optional
           # Instruct latexmk to use LuaLaTeX

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Each input is provided as a key inside the `with` section of the action.
 
 * `args`
 
-    The extra arguments to be passed to the LaTeX engine. By default, it is `-pdf -file-line-error -halt-on-error -interaction=nonstopmode`. This tells `latexmk` to use `pdflatex`. Refer to [`latexmk` document](http://texdoc.net/texmf-dist/doc/support/latexmk/latexmk.pdf) for more information.
+    The extra arguments to be passed to the LaTeX engine. By default, it is `-pdf -file-line-error -interaction=nonstopmode`. This tells `latexmk` to use `pdflatex`. Refer to [`latexmk` document](http://texdoc.net/texmf-dist/doc/support/latexmk/latexmk.pdf) for more information.
 
 * `extra_system_packages`
 
@@ -72,6 +72,10 @@ Each input is provided as a key inside the `with` section of the action.
 * `post_compile`
 
     Arbitrary bash codes to be executed after compiling LaTeX documents. For example, `post_compile: "latexmk -c"` to clean up temporary files.
+
+* `continue_on_error`
+
+    Ignore LaTeX build errors, not set by default.
 
 **The following inputs are only valid if the input `compiler` is not changed.**
 

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: latexmk
   args:
     description: Extra arguments to be passed to the LaTeX engine
-    default: "-pdf -file-line-error -halt-on-error -interaction=nonstopmode"
+    default: "-pdf -file-line-error -interaction=nonstopmode"
   extra_packages:
     description: "[Deprecated] Install extra packages by tlmgr"
   extra_system_packages:
@@ -27,6 +27,8 @@ inputs:
     description: Arbitrary bash codes to be executed before compiling LaTeX documents
   post_compile:
     description: Arbitrary bash codes to be executed after compiling LaTeX documents
+  continue_on_error:
+    description: Ignore LaTeX build errors
   latexmk_shell_escape:
     description: Instruct latexmk to enable --shell-escape
   latexmk_use_lualatex:
@@ -48,6 +50,7 @@ runs:
     - ${{ inputs.extra_fonts }}
     - ${{ inputs.pre_compile }}
     - ${{ inputs.post_compile }}
+    - ${{ inputs.continue_on_error }}
     - ${{ inputs.latexmk_shell_escape }}
     - ${{ inputs.latexmk_use_lualatex }}
     - ${{ inputs.latexmk_use_xelatex }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,9 +27,10 @@ extra_system_packages="${8}"
 extra_fonts="${9}"
 pre_compile="${10}"
 post_compile="${11}"
-latexmk_shell_escape="${12}"
-latexmk_use_lualatex="${13}"
-latexmk_use_xelatex="${14}"
+continue_on_error="${12}"
+latexmk_shell_escape="${13}"
+latexmk_use_lualatex="${14}"
+latexmk_use_xelatex="${15}"
 
 if [[ -z "$root_file" ]]; then
   error "Input 'root_file' is missing."
@@ -58,7 +59,7 @@ fi
 if [[ -z "$compiler" && -z "$args" ]]; then
   warn "Input 'compiler' and 'args' are both empty. Reset them to default values."
   compiler="latexmk"
-  args="-pdf -file-line-error -halt-on-error -interaction=nonstopmode"
+  args="-pdf -file-line-error -interaction=nonstopmode"
 fi
 
 IFS=' ' read -r -a args <<< "$args"
@@ -66,6 +67,10 @@ IFS=' ' read -r -a args <<< "$args"
 if [[ "$compiler" = "latexmk" ]]; then
   if [[ -n "$latexmk_shell_escape" ]]; then
     args+=("-shell-escape")
+  fi
+
+  if [[ -z "$continue_on_error" ]]; then
+    args+=("-halt-on-error")
   fi
 
   if [[ -n "$latexmk_use_lualatex" && -n "$latexmk_use_xelatex" ]]; then
@@ -147,6 +152,10 @@ if [[ -n "$pre_compile" ]]; then
   eval "$pre_compile"
 fi
 
+if [[ -n "$continue_on_error" ]]; then
+  set +e
+fi
+
 for f in "${root_file[@]}"; do
   if [[ -z "$f" ]]; then
     continue
@@ -170,7 +179,6 @@ for f in "${root_file[@]}"; do
     popd >/dev/null
   fi
 done
-
 
 if [[ -n "$post_compile" ]]; then
   info "Run post compile commands"

--- a/test/error.tex
+++ b/test/error.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+\usepackage{blindtext}
+\begin{document}
+\undefinedcommand
+\blinddocument
+\end{document}


### PR DESCRIPTION
Rel #73

If `continue_on_error` isn't an empty string, do ´set +e´ before compilation. Otherwise, and only when using `latexmk`, set `-halt-on-error`. My intention here was that compilation should "continue" both in the sense that
- the following files will be compiled, and
- the compiler should also attempt to continue compiling the _current_ file