### PR TITLE
fix: add executable permission to `arara` on some images

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,6 +38,10 @@ if ! command -v git &>/dev/null; then
 fi
 git config --system --add safe.directory /github/workspace
 
+# fix arara permission on some images
+arara_path=$(realpath "$(command -v arara)")
+[[ ! -x "$arara_path" ]] && chmod +x "$arara_path"
+
 if [[ -z "$root_file" ]]; then
   error "Input 'root_file' is missing."
 fi


### PR DESCRIPTION
This action `- uses: xu-cheng/latex-action@v2-texlive2021` would fail with the following test:

https://github.com/xu-cheng/latex-action/blob/8c9adec310ed05afa3650bd2727d1e71ca1dfd0d/.github/workflows/test.yml#L94-L100

The `v2-texlive2021` action uses the pinned docker image `ghcr.io/xu-cheng/texlive-full:20220301`
https://github.com/xu-cheng/latex-action/blob/8c9adec310ed05afa3650bd2727d1e71ca1dfd0d/.github/workflows/release.yml#L10-L17

The `arara` binary in the image is located at `/opt/texlive/texdir/bin/x86_64-linuxmusl/arara`, which is a symlink file to the real file at `/opt/texlive/texdir/texmf-dist/scripts/arara/arara.sh`.

Strangely, the `arara` binary in image `ghcr.io/xu-cheng/texlive-full:20220301` doesn't have the executable permission, which causes the test to fail.
 
```bash
$ docker run --rm ghcr.io/xu-cheng/texlive-full:20220301 ls -l /opt/texlive/texdir/texmf-dist/scripts/arara/arara.sh
-rw-r--r--    1 root     root           576 Feb 27  2022 /opt/texlive/texdir/texmf-dist/scripts/arara/arara.sh
```

The failed test run can be found at: https://github.com/zydou/latex-action/actions/runs/5973694821/job/16206429136

This PR has been tested at: https://github.com/zydou/latex-action/actions/runs/5973740389