### PR TITLE
fix: use `Doulos SIL` to test `extra_fonts` function

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,14 +83,14 @@ jobs:
           latexmk_use_lualatex: true
       - name: Download extra fonts
         run: |
-          curl -OL https://github.com/google/fonts/raw/main/ofl/notosans/NotoSans-Regular.ttf
+          curl -OL https://github.com/silnrsi/font-doulos/raw/78bd59af3dd78e8276918471d8a228348bf741e8/references/v6200/DoulosSIL-Regular.ttf
       - name: Compile LaTeX document with extra_fonts
         uses: ./
         with:
           root_file: extra_fonts.tex
           working_directory: test/
           latexmk_use_xelatex: true
-          extra_fonts: "./../NotoSans-Regular.ttf"
+          extra_fonts: "./../DoulosSIL-Regular.ttf"
       - name: Compile LaTeX document with arara and graphviz
         uses: ./
         with:

--- a/test/extra_fonts.tex
+++ b/test/extra_fonts.tex
@@ -1,6 +1,6 @@
 \documentclass{article}
 \usepackage{fontspec}
-\setmainfont{NotoSans-Regular}
+\setmainfont{Doulos SIL}
 \begin{document}
 Hello world!
 \end{document}


### PR DESCRIPTION
There are two reasons for choosing a different font than `NotoSans-Regular`:

1. The url of font `NotoSans-Regular` is a dead link. 
https://github.com/xu-cheng/latex-action/blob/8c9adec310ed05afa3650bd2727d1e71ca1dfd0d/.github/workflows/test.yml#L86

2. Font `NotoSans-Regular` is a built-in font in recent texlive versions, so the `extra-fonts.tex` can be always compiled because `NotoSans-Regular` is no longer an extra font.
```bash
$ docker run --rm ghcr.io/xu-cheng/texlive-full:latest fc-list | grep NotoSans-Regular
/opt/texlive/texdir/texmf-dist/fonts/type1/google/noto/NotoSans-Regular.pfb: Noto Sans:style=Regular
/opt/texlive/texdir/texmf-dist/fonts/truetype/google/noto/NotoSans-Regular.ttf: Noto Sans:style=Regular
```
In [this run](https://github.com/zydou/latex-action/actions/runs/5974188103), it is evident that despite the font `NotoSans-Regular` URL being dead, the tags `20220301`, `20230301`, and `latest` still passed successfully.

I choose the [DoulosSIL](https://github.com/silnrsi/font-doulos) font because it is not included in the latest texlive, and it is a free and open font. ([LICENSE](https://github.com/silnrsi/font-doulos/blob/3c86a32ac27d9306bf177e7f98facdc546a29593/OFL.txt))

This PR has been tested at: https://github.com/zydou/latex-action/actions/runs/5974262902

