### PR TITLE
feat: add an option to select texlive version directly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,0 @@
-/.git*
-/action.yml
-/test/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
   workflow_dispatch:
 jobs:
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        texlive_version: [2020, 2021, 2022, latest]
     runs-on: ubuntu-latest
     steps:
       - name: Set up Git repository
@@ -14,11 +18,13 @@ jobs:
       - name: Compile basic LaTeX document
         uses: ./
         with:
+          texlive_version: ${{ matrix.texlive_version }}
           root_file: test.tex
           working_directory: test/
       - name: Compile LaTeX document with pre/post compile actions
         uses: ./
         with:
+          texlive_version: ${{ matrix.texlive_version }}
           root_file: test.tex
           working_directory: test/
           pre_compile: |
@@ -28,6 +34,7 @@ jobs:
       - name: Compile multiple LaTeX documents
         uses: ./
         with:
+          texlive_version: ${{ matrix.texlive_version }}
           root_file: |
             file1.tex
             file2.tex
@@ -35,12 +42,14 @@ jobs:
       - name: Compile multiple LaTeX documents using glob
         uses: ./
         with:
+          texlive_version: ${{ matrix.texlive_version }}
           root_file: "glob_test*.tex"
           glob_root_file: true
           working_directory: test/
       - name: Compile multiple LaTeX documents in different directories
         uses: ./
         with:
+          texlive_version: ${{ matrix.texlive_version }}
           root_file: "subdir*/main.tex"
           glob_root_file: true
           working_directory: test/
@@ -48,6 +57,7 @@ jobs:
       - name: Compile multiple LaTeX documents in different directories using extended glob
         uses: ./
         with:
+          texlive_version: ${{ matrix.texlive_version }}
           root_file: "extglob/!(subdir3)_glob/*.tex"
           glob_root_file: true
           working_directory: test/
@@ -55,6 +65,7 @@ jobs:
       - name: Compile multiple LaTeX documents in different directories using glob star
         uses: ./
         with:
+          texlive_version: ${{ matrix.texlive_version }}
           root_file: "globstar/**/*.tex"
           glob_root_file: true
           working_directory: test/
@@ -62,21 +73,25 @@ jobs:
       - name: Compile LaTeX document with math symbols
         uses: ./
         with:
+          texlive_version: ${{ matrix.texlive_version }}
           root_file: math.tex
           working_directory: test/
       - name: Compile LaTeX document with biblatex/biber
         uses: ./
         with:
+          texlive_version: ${{ matrix.texlive_version }}
           root_file: biblatex.tex
           working_directory: test/
       - name: Compile LaTeX document with eps figure
         uses: ./
         with:
+          texlive_version: ${{ matrix.texlive_version }}
           root_file: eps.tex
           working_directory: test/
       - name: Compile LaTeX document with minted and lualatex
         uses: ./
         with:
+          texlive_version: ${{ matrix.texlive_version }}
           root_file: minted.tex
           working_directory: test/
           latexmk_shell_escape: true
@@ -87,6 +102,7 @@ jobs:
       - name: Compile LaTeX document with extra_fonts
         uses: ./
         with:
+          texlive_version: ${{ matrix.texlive_version }}
           root_file: extra_fonts.tex
           working_directory: test/
           latexmk_use_xelatex: true
@@ -94,6 +110,7 @@ jobs:
       - name: Compile LaTeX document with arara and graphviz
         uses: ./
         with:
+          texlive_version: ${{ matrix.texlive_version }}
           root_file: graphviz.tex
           working_directory: test/
           compiler: arara
@@ -101,6 +118,7 @@ jobs:
       - name: Compile LaTeX document with continue_on_error
         uses: ./
         with:
+          texlive_version: ${{ matrix.texlive_version }}
           root_file: |
             error.tex
             not_error.tex

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM ghcr.io/xu-cheng/texlive-full:latest
-
-COPY \
-  LICENSE \
-  README.md \
-  entrypoint.sh \
-  /root/
-
-ENTRYPOINT ["/root/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Each input is provided as a key inside the `with` section of the action.
 
     The root LaTeX file to be compiled. This input is required. You can also pass multiple files as a multi-line string to compile multiple documents. For example:
     ```yaml
-    - uses: xu-cheng/latex-action@v2
+    - uses: xu-cheng/latex-action@v3
       with:
         root_file: |
           file1.tex
@@ -27,7 +27,7 @@ Each input is provided as a key inside the `with` section of the action.
 
     If set, interpret the `root_file` input as bash glob pattern. For example:
     ```yaml
-    - uses: xu-cheng/latex-action@v2
+    - uses: xu-cheng/latex-action@v3
       with:
         root_file: "*.tex"
         glob_root_file: true
@@ -61,7 +61,7 @@ Each input is provided as a key inside the `with` section of the action.
 
     Install extra `.ttf`/`.otf` fonts to be used by `fontspec`. You can also pass multiple files as a multi-line string. Each file path will be interpreted as glob pattern. For example:
     ```yaml
-    - uses: xu-cheng/latex-action@v2
+    - uses: xu-cheng/latex-action@v3
       with:
         root_file: main.tex
         extra_fonts: |
@@ -76,6 +76,26 @@ Each input is provided as a key inside the `with` section of the action.
 * `post_compile`
 
     Arbitrary bash codes to be executed after compiling LaTeX documents. For example, `post_compile: "latexmk -c"` to clean up temporary files.
+
+* `texlive_version`
+
+    The version of TeXLive to be used. Supported inputs include 2020, 2021, 2022, 2023, and latest. By default the latest TeXLive is used. This input cannot co-exist with `docker_image` input. An  example to use this input:
+    ```yaml
+    - uses: xu-cheng/latex-action@v3
+      with:
+        root_file: main.tex
+        texlive_version: 2022
+    ```
+
+* `docker_image`
+
+    Custom which docker image to be used. Only [latex-docker images](https://github.com/xu-cheng/latex-docker/pkgs/container/texlive-full) are supported. For example if you want to pin the docker image:
+    ```yaml
+    - uses: xu-cheng/latex-action@v3
+      with:
+        root_file: main.tex
+        docker_image: ghcr.io/xu-cheng/texlive-full:20230801
+    ```
 
 **The following inputs are only valid if the input `compiler` is not changed.**
 
@@ -103,7 +123,7 @@ jobs:
       - name: Set up Git repository
         uses: actions/checkout@v3
       - name: Compile LaTeX document
-        uses: xu-cheng/latex-action@v2
+        uses: xu-cheng/latex-action@v3
         with:
           root_file: main.tex
       - name: Upload PDF file
@@ -120,14 +140,14 @@ jobs:
 By default, this action uses pdfLaTeX. If you want to use XeLaTeX or LuaLaTeX, you can set the `latexmk_use_xelatex` or `latexmk_use_lualatex` input respectively. For example:
 
 ```yaml
-- uses: xu-cheng/latex-action@v2
+- uses: xu-cheng/latex-action@v3
   with:
     root_file: main.tex
     latexmk_use_xelatex: true
 ```
 
 ```yaml
-- uses: xu-cheng/latex-action@v2
+- uses: xu-cheng/latex-action@v3
   with:
     root_file: main.tex
     latexmk_use_lualatex: true
@@ -140,7 +160,7 @@ Alternatively, you could create a `.latexmkrc` file. Refer to the [`latexmk` doc
 To enable `--shell-escape`, set the `latexmk_shell_escape` input.
 
 ```yaml
-- uses: xu-cheng/latex-action@v2
+- uses: xu-cheng/latex-action@v3
   with:
     root_file: main.tex
     latexmk_shell_escape: true
@@ -172,7 +192,7 @@ Sometimes you may have custom package (`.sty`) or class (`.cls`) files in other 
   run: |
     curl -OL https://example.com/custom_template.zip
     unzip custom_template.zip
-- uses: xu-cheng/latex-action@v2
+- uses: xu-cheng/latex-action@v3
   with:
     root_file: main.tex
   env:
@@ -182,17 +202,6 @@ Sometimes you may have custom package (`.sty`) or class (`.cls`) files in other 
 Noted that you should NOT use `{{ github.workspace }}` or `$GITHUB_WORKSPACE` in `TEXINPUTS`. This action works in a separated docker container, where the workspace directory is mounted into it. Therefore, the workspace directory inside the docker container is different from `github.workspace`.
 
 You can find more information of `TEXINPUTS` [here](https://tex.stackexchange.com/a/93733).
-
-### How to use old versions of TeXLive?
-
-By default, this action always uses the latest docker image that contains the latest TeXLive updates. If you want to use old versions of TeXLive, you can change the action version tag accordingly. Currently, three last old versions of TeXLive are supported. 
-
-```yaml
-- uses: xu-cheng/latex-action@v2             # TeXLive 2023
-- uses: xu-cheng/latex-action@v2-texlive2022 # TeXLive 2022
-- uses: xu-cheng/latex-action@v2-texlive2021 # TeXLive 2021
-- uses: xu-cheng/latex-action@v2-texlive2020 # TeXLive 2020
-```
 
 ### It fails due to `xindy` cannot be found.
 

--- a/action.sh
+++ b/action.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+error() {
+  echo "::error :: $1"
+  exit 1
+}
+
+texlive_version="${1}"
+docker_image="${2}"
+shift 2
+
+if [[ -n "$texlive_version" && -n "$docker_image" ]]; then
+  error "Input 'texlive_version' and 'docker_image' cannot co-exist".
+fi
+
+if [[ -z "$docker_image" ]]; then
+  case "$texlive_version" in
+  "" | "latest" | "2023")
+    image_version="latest"
+    ;;
+  "2022")
+    image_version="20230301"
+    ;;
+  "2021")
+    image_version="20220201"
+    ;;
+  "2020")
+    image_version="20210301"
+    ;;
+  *)
+    error "TeX Live version $texlive_version is not supported. The currently supported versions are 2020-2023 or latest."
+    ;;
+  esac
+  docker_image="ghcr.io/xu-cheng/texlive-full:$image_version"
+fi
+
+docker run --rm \
+  -e "TEXINPUTS" \
+  -e "HOME" \
+  -e "GITHUB_JOB" \
+  -e "GITHUB_REF" \
+  -e "GITHUB_SHA" \
+  -e "GITHUB_REPOSITORY" \
+  -e "GITHUB_REPOSITORY_OWNER" \
+  -e "GITHUB_REPOSITORY_OWNER_ID" \
+  -e "GITHUB_RUN_ID" \
+  -e "GITHUB_RUN_NUMBER" \
+  -e "GITHUB_RETENTION_DAYS" \
+  -e "GITHUB_RUN_ATTEMPT" \
+  -e "GITHUB_REPOSITORY_ID" \
+  -e "GITHUB_ACTOR_ID" \
+  -e "GITHUB_ACTOR" \
+  -e "GITHUB_TRIGGERING_ACTOR" \
+  -e "GITHUB_WORKFLOW" \
+  -e "GITHUB_HEAD_REF" \
+  -e "GITHUB_BASE_REF" \
+  -e "GITHUB_EVENT_NAME" \
+  -e "GITHUB_SERVER_URL" \
+  -e "GITHUB_API_URL" \
+  -e "GITHUB_GRAPHQL_URL" \
+  -e "GITHUB_REF_NAME" \
+  -e "GITHUB_REF_PROTECTED" \
+  -e "GITHUB_REF_TYPE" \
+  -e "GITHUB_WORKFLOW_REF" \
+  -e "GITHUB_WORKFLOW_SHA" \
+  -e "GITHUB_WORKSPACE" \
+  -e "GITHUB_ACTION" \
+  -e "GITHUB_EVENT_PATH" \
+  -e "GITHUB_ACTION_REPOSITORY" \
+  -e "GITHUB_ACTION_REF" \
+  -e "GITHUB_PATH" \
+  -e "GITHUB_ENV" \
+  -e "GITHUB_STEP_SUMMARY" \
+  -e "GITHUB_STATE" \
+  -e "GITHUB_OUTPUT" \
+  -e "RUNNER_OS" \
+  -e "RUNNER_ARCH" \
+  -e "RUNNER_NAME" \
+  -e "RUNNER_ENVIRONMENT" \
+  -e "RUNNER_TOOL_CACHE" \
+  -e "RUNNER_TEMP" \
+  -e "RUNNER_WORKSPACE" \
+  -e "ACTIONS_RUNTIME_URL" \
+  -e "ACTIONS_RUNTIME_TOKEN" \
+  -e "ACTIONS_CACHE_URL" \
+  -e GITHUB_ACTIONS=true \
+  -e CI=true \
+  -v "/var/run/docker.sock":"/var/run/docker.sock" \
+  -v "$HOME:$HOME" \
+  -v "$GITHUB_ENV:$GITHUB_ENV" \
+  -v "$GITHUB_OUTPUT:$GITHUB_OUTPUT" \
+  -v "$GITHUB_STEP_SUMMARY:$GITHUB_STEP_SUMMARY" \
+  -v "$GITHUB_PATH:$GITHUB_PATH" \
+  -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
+  -v "$GITHUB_ACTION_PATH/entryoint.sh":/entrypoint.sh \
+  -w "$GITHUB_WORKSPACE" \
+  --entrypoint "/entrypoint.sh" \
+  "$docker_image" \
+  "$@"

--- a/action.sh
+++ b/action.sh
@@ -99,7 +99,7 @@ run docker run --rm \
   -v "$GITHUB_STEP_SUMMARY:$GITHUB_STEP_SUMMARY" \
   -v "$GITHUB_PATH:$GITHUB_PATH" \
   -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
-  -v "$GITHUB_ACTION_PATH/entryoint.sh":/entrypoint.sh \
+  -v "$GITHUB_ACTION_PATH/entrypoint.sh":/entrypoint.sh \
   -w "$GITHUB_WORKSPACE" \
   --entrypoint "/entrypoint.sh" \
   "$docker_image" \

--- a/action.sh
+++ b/action.sh
@@ -2,6 +2,11 @@
 
 set -eo pipefail
 
+run() {
+  echo -e "\033[1;34m$@\033[0m"
+  "$@"
+}
+
 error() {
   echo "::error :: $1"
   exit 1
@@ -36,7 +41,7 @@ if [[ -z "$docker_image" ]]; then
   docker_image="ghcr.io/xu-cheng/texlive-full:$image_version"
 fi
 
-docker run --rm \
+run docker run --rm \
   -e "TEXINPUTS" \
   -e "HOME" \
   -e "GITHUB_JOB" \

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,10 @@ name: Github Action for LaTeX
 description: GitHub Action to compile LaTeX documents
 author: Cheng XU
 inputs:
+  texlive_version:
+    description: The version of TeX Live to be used
+  docker_image:
+    description: The docker image to be used
   root_file:
     description: The root LaTeX file to be compiled
     required: true
@@ -35,53 +39,30 @@ inputs:
     description: Instruct latexmk to use LuaLaTeX
   latexmk_use_xelatex:
     description: Instruct latexmk to use XeLaTeX
-  texlive_version:
-    description: The version of TeX Live to be used
-    default: latest
 
 runs:
   using: composite
   steps:
     - shell: bash
-      name: Choose pinned texlive docker tag
       run: |
-        if [[ "${{ inputs.texlive_version }}" == "2020" ]]; then
-        echo "texlive_version=20210301" >> "${GITHUB_ENV}"
-        elif [[ "${{ inputs.texlive_version }}" == "2021" ]]; then
-        echo "texlive_version=20220201" >> "${GITHUB_ENV}"
-        elif [[ "${{ inputs.texlive_version }}" == "2022" ]]; then
-        echo "texlive_version=20230301" >> "${GITHUB_ENV}"
-        elif [[ "${{ inputs.texlive_version }}" == "latest" ]]; then
-        echo "texlive_version=latest" >> "${GITHUB_ENV}"
-        else
-        echo "TeX Live version ${{ inputs.texlive_version }} is not supported."
-        echo "The currently supported versions are 2020, 2021, 2022, and latest."
-        exit 1
-        fi
-    - shell: bash
-      run: >
-        docker run --rm
-        -v "${PWD}":/github/workspace
-        -v "${GITHUB_ACTION_PATH}/entrypoint.sh":/entrypoint.sh
-        -w /github/workspace
-        --entrypoint "/entrypoint.sh"
-        ghcr.io/xu-cheng/texlive-full:${{ env.texlive_version }}
-        "${{ inputs.root_file }}"
-        "${{ inputs.glob_root_file }}"
-        "${{ inputs.working_directory }}"
-        "${{ inputs.work_in_root_file_dir }}"
-        "${{ inputs.continue_on_error }}"
-        "${{ inputs.compiler }}"
-        "${{ inputs.args }}"
-        "${{ inputs.extra_packages }}"
-        "${{ inputs.extra_system_packages }}"
-        "${{ inputs.extra_fonts }}"
-        "${{ inputs.pre_compile }}"
-        "${{ inputs.post_compile }}"
-        "${{ inputs.latexmk_shell_escape }}"
-        "${{ inputs.latexmk_use_lualatex }}"
-        "${{ inputs.latexmk_use_xelatex }}"
-        "${{ env.texinputs }}"
+        "${GITHUB_ACTION_PATH}/action.sh" \
+          "${{ inputs.texlive_version }}" \
+          "${{ inputs.docker_image }}" \
+          "${{ inputs.root_file }}" \
+          "${{ inputs.glob_root_file }}" \
+          "${{ inputs.working_directory }}" \
+          "${{ inputs.work_in_root_file_dir }}" \
+          "${{ inputs.continue_on_error }}" \
+          "${{ inputs.compiler }}" \
+          "${{ inputs.args }}" \
+          "${{ inputs.extra_packages }}" \
+          "${{ inputs.extra_system_packages }}" \
+          "${{ inputs.extra_fonts }}" \
+          "${{ inputs.pre_compile }}" \
+          "${{ inputs.post_compile }}" \
+          "${{ inputs.latexmk_shell_escape }}" \
+          "${{ inputs.latexmk_use_lualatex }}" \
+          "${{ inputs.latexmk_use_xelatex }}"
 
 branding:
   icon: book

--- a/action.yml
+++ b/action.yml
@@ -35,25 +35,54 @@ inputs:
     description: Instruct latexmk to use LuaLaTeX
   latexmk_use_xelatex:
     description: Instruct latexmk to use XeLaTeX
+  texlive_version:
+    description: The version of TeX Live to be used
+    default: latest
+
 runs:
-  using: docker
-  image: Dockerfile
-  args:
-    - ${{ inputs.root_file }}
-    - ${{ inputs.glob_root_file }}
-    - ${{ inputs.working_directory }}
-    - ${{ inputs.work_in_root_file_dir }}
-    - ${{ inputs.continue_on_error }}
-    - ${{ inputs.compiler }}
-    - ${{ inputs.args }}
-    - ${{ inputs.extra_packages }}
-    - ${{ inputs.extra_system_packages }}
-    - ${{ inputs.extra_fonts }}
-    - ${{ inputs.pre_compile }}
-    - ${{ inputs.post_compile }}
-    - ${{ inputs.latexmk_shell_escape }}
-    - ${{ inputs.latexmk_use_lualatex }}
-    - ${{ inputs.latexmk_use_xelatex }}
+  using: composite
+  steps:
+    - shell: bash
+      name: Choose pinned texlive docker tag
+      run: |
+        if [[ "${{ inputs.texlive_version }}" == "2020" ]]; then
+        echo "texlive_version=20210301" >> "${GITHUB_ENV}"
+        elif [[ "${{ inputs.texlive_version }}" == "2021" ]]; then
+        echo "texlive_version=20220201" >> "${GITHUB_ENV}"
+        elif [[ "${{ inputs.texlive_version }}" == "2022" ]]; then
+        echo "texlive_version=20230301" >> "${GITHUB_ENV}"
+        elif [[ "${{ inputs.texlive_version }}" == "latest" ]]; then
+        echo "texlive_version=latest" >> "${GITHUB_ENV}"
+        else
+        echo "TeX Live version ${{ inputs.texlive_version }} is not supported."
+        echo "The currently supported versions are 2020, 2021, 2022, and latest."
+        exit 1
+        fi
+    - shell: bash
+      run: >
+        docker run --rm
+        -v "${PWD}":/github/workspace
+        -v "${GITHUB_ACTION_PATH}/entrypoint.sh":/entrypoint.sh
+        -w /github/workspace
+        --entrypoint "/entrypoint.sh"
+        ghcr.io/xu-cheng/texlive-full:${{ env.texlive_version }}
+        "${{ inputs.root_file }}"
+        "${{ inputs.glob_root_file }}"
+        "${{ inputs.working_directory }}"
+        "${{ inputs.work_in_root_file_dir }}"
+        "${{ inputs.continue_on_error }}"
+        "${{ inputs.compiler }}"
+        "${{ inputs.args }}"
+        "${{ inputs.extra_packages }}"
+        "${{ inputs.extra_system_packages }}"
+        "${{ inputs.extra_fonts }}"
+        "${{ inputs.pre_compile }}"
+        "${{ inputs.post_compile }}"
+        "${{ inputs.latexmk_shell_escape }}"
+        "${{ inputs.latexmk_use_lualatex }}"
+        "${{ inputs.latexmk_use_xelatex }}"
+        "${{ env.texinputs }}"
+
 branding:
   icon: book
   color: blue

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,12 +31,18 @@ post_compile="${12}"
 latexmk_shell_escape="${13}"
 latexmk_use_lualatex="${14}"
 latexmk_use_xelatex="${15}"
+env_texinputs="${16}"
 
 # install git on old images
 if ! command -v git &>/dev/null; then
   apk --no-cache add git
 fi
 git config --system --add safe.directory /github/workspace
+
+# setup user-defined environment variables
+if [[ -n "$env_texinputs" ]]; then
+  export TEXINPUTS="$env_texinputs"
+fi
 
 if [[ -z "$root_file" ]]; then
   error "Input 'root_file' is missing."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,18 +31,12 @@ post_compile="${12}"
 latexmk_shell_escape="${13}"
 latexmk_use_lualatex="${14}"
 latexmk_use_xelatex="${15}"
-env_texinputs="${16}"
 
 # install git on old images
 if ! command -v git &>/dev/null; then
   apk --no-cache add git
 fi
-git config --system --add safe.directory /github/workspace
-
-# setup user-defined environment variables
-if [[ -n "$env_texinputs" ]]; then
-  export TEXINPUTS="$env_texinputs"
-fi
+git config --system --add safe.directory "$GITHUB_WORKSPACE"
 
 if [[ -z "$root_file" ]]; then
   error "Input 'root_file' is missing."


### PR DESCRIPTION
This PR adds the `texlive_version` option in the inputs parameters to select texlive version directly, as discussed in #129 

You can find the test run at: https://github.com/zydou/latex-action/actions/runs/5995341522. Although all jobs passed, there is an annotation stating `Process completed with exit code 12.`, which is expected because trying to compile the `error.tex` gives an exit code 12.
