### PR TITLE
fix: add default values for boolean option and use `=` to test them

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,8 +13,10 @@ inputs:
     description: The working directory for this action
   work_in_root_file_dir:
     description: Change directory into each root file's directory before compiling each documents
+    default: "false"
   continue_on_error:
     description: Continuing to build document even with LaTeX build errors
+    default: "false"
   compiler:
     description: The LaTeX engine to be invoked
     default: latexmk
@@ -33,10 +35,13 @@ inputs:
     description: Arbitrary bash codes to be executed after compiling LaTeX documents
   latexmk_shell_escape:
     description: Instruct latexmk to enable --shell-escape
+    default: "false"
   latexmk_use_lualatex:
     description: Instruct latexmk to use LuaLaTeX
+    default: "false"
   latexmk_use_xelatex:
     description: Instruct latexmk to use XeLaTeX
+    default: "false"
 
 runs:
   using: composite

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,7 +68,6 @@ IFS=' ' read -r -a args <<<"$args"
 
 if [[ "$compiler" = "latexmk" ]]; then
   if [[ "$latexmk_shell_escape" = "true" ]]; then
-    info "Option latexmk_shell_escape is enabled."
     args+=("-shell-escape")
   fi
 
@@ -77,7 +76,6 @@ if [[ "$compiler" = "latexmk" ]]; then
   fi
 
   if [[ "$latexmk_use_lualatex" = "true" ]]; then
-    info "Option latexmk_use_lualatex is enabled."
     for i in "${!args[@]}"; do
       if [[ "${args[i]}" = "-pdf" ]]; then
         unset 'args[i]'
@@ -96,7 +94,6 @@ if [[ "$compiler" = "latexmk" ]]; then
   fi
 
   if [[ "$latexmk_use_xelatex" = "true" ]]; then
-    info "Option latexmk_use_xelatex is enabled."
     for i in "${!args[@]}"; do
       if [[ "${args[i]}" = "-pdf" ]]; then
         unset 'args[i]'
@@ -161,7 +158,6 @@ for f in "${root_file[@]}"; do
   fi
 
   if [[ "$work_in_root_file_dir" = "true" ]]; then
-    info "Option work_in_root_file_dir is enabled."
     pushd "$(dirname "$f")" >/dev/null
     f="$(basename "$f")"
     info "Compile $f in $PWD"
@@ -176,7 +172,6 @@ for f in "${root_file[@]}"; do
   "$compiler" "${args[@]}" "$f" || ret="$?"
   if [[ "$ret" -ne 0 ]]; then
     if [[ "$continue_on_error" = "true" ]]; then
-      info "Option continue_on_error is enabled."
       exit_code="$ret"
     else
       exit "$ret"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,15 +67,17 @@ fi
 IFS=' ' read -r -a args <<<"$args"
 
 if [[ "$compiler" = "latexmk" ]]; then
-  if [[ -n "$latexmk_shell_escape" ]]; then
+  if [[ "$latexmk_shell_escape" = "true" ]]; then
+    info "Option latexmk_shell_escape is enabled."
     args+=("-shell-escape")
   fi
 
-  if [[ -n "$latexmk_use_lualatex" && -n "$latexmk_use_xelatex" ]]; then
+  if [[ "$latexmk_use_lualatex" = "true" && "$latexmk_use_xelatex" = "true" ]]; then
     error "Input 'latexmk_use_lualatex' and 'latexmk_use_xelatex' cannot be used at the same time."
   fi
 
-  if [[ -n "$latexmk_use_lualatex" ]]; then
+  if [[ "$latexmk_use_lualatex" = "true" ]]; then
+    info "Option latexmk_use_lualatex is enabled."
     for i in "${!args[@]}"; do
       if [[ "${args[i]}" = "-pdf" ]]; then
         unset 'args[i]'
@@ -93,7 +95,8 @@ if [[ "$compiler" = "latexmk" ]]; then
     args=("${args[@]/#-interaction=/--interaction=}")
   fi
 
-  if [[ -n "$latexmk_use_xelatex" ]]; then
+  if [[ "$latexmk_use_xelatex" = "true" ]]; then
+    info "Option latexmk_use_xelatex is enabled."
     for i in "${!args[@]}"; do
       if [[ "${args[i]}" = "-pdf" ]]; then
         unset 'args[i]'
@@ -103,7 +106,7 @@ if [[ "$compiler" = "latexmk" ]]; then
   fi
 else
   for VAR in "${!latexmk_@}"; do
-    if [[ -n "${!VAR}" ]]; then
+    if [[ "${!VAR}" = "true" ]]; then
       error "Input '${VAR}' is only valid if input 'compiler' is set to 'latexmk'."
     fi
   done
@@ -157,7 +160,8 @@ for f in "${root_file[@]}"; do
     continue
   fi
 
-  if [[ -n "$work_in_root_file_dir" ]]; then
+  if [[ "$work_in_root_file_dir" = "true" ]]; then
+    info "Option work_in_root_file_dir is enabled."
     pushd "$(dirname "$f")" >/dev/null
     f="$(basename "$f")"
     info "Compile $f in $PWD"
@@ -171,14 +175,15 @@ for f in "${root_file[@]}"; do
 
   "$compiler" "${args[@]}" "$f" || ret="$?"
   if [[ "$ret" -ne 0 ]]; then
-    if [[ -n "$continue_on_error" ]]; then
+    if [[ "$continue_on_error" = "true" ]]; then
+      info "Option continue_on_error is enabled."
       exit_code="$ret"
     else
       exit "$ret"
     fi
   fi
 
-  if [[ -n "$work_in_root_file_dir" ]]; then
+  if [[ "$work_in_root_file_dir" = "true" ]]; then
     popd >/dev/null
   fi
 done


### PR DESCRIPTION
Use `[[ $option = 'true' ]]` instead of `[[ -n $option ]]` to check enabled option.

`[[ -n $option ]]` will return true if the string is not empty even if we set `option=false`, because bash treats `false` as a non-empty string.

For instance, some people follow this workflow:

```yaml
- uses: xu-cheng/latex-action@v3
  with:
    boolean_option: true
    # other options...
```

Later on, they make changes to their project and need to disable the `boolean_option` using this workflow:

```yaml
- uses: xu-cheng/latex-action@v3
  with:
    boolean_option: false
    # other options...
```

Unfortunately, this won't work because `[[ -n $boolean_option ]]` will still return true. The only correct way to disable that option is by deleting the line. However, this can be confusing and misleading, making it difficult to identify the bug without logging.
