### PR TITLE
chore: update checkout and upload-artifact actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Compile basic LaTeX document
         uses: ./
         with:
@@ -144,7 +144,7 @@ jobs:
           file test/abc.pdf | grep -q ' PDF '
           file test/not_error.pdf | grep -q ' PDF '
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test
           path: test

--- a/README.md
+++ b/README.md
@@ -111,13 +111,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Compile LaTeX document
         uses: xu-cheng/latex-action@v3
         with:
           root_file: main.tex
       - name: Upload PDF file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: PDF
           path: main.pdf
@@ -162,7 +162,7 @@ The PDF file will be in the same folder as that of the LaTeX source in the CI en
 * You can use [`@actions/upload-artifact`](https://github.com/actions/upload-artifact) to upload a zip containing the PDF file to the workflow tab. For example you can add
 
   ```yaml
-  - uses: actions/upload-artifact@v3
+  - uses: actions/upload-artifact@v4
     with:
       name: PDF
       path: main.pdf


### PR DESCRIPTION
Update actions/checkout from 3 to 4
Update actions/upload-artifact from 3 to 4

Without this there is a warning in the output:

Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.