### PR TITLE
fix: don't word split during filename expansion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,12 @@ jobs:
           texlive_version: ${{ matrix.texlive_version }}
           root_file: test.tex
           working_directory: test/
+      - name: Compile LaTeX document with space in filename
+        uses: ./
+        with:
+          texlive_version: ${{ matrix.texlive_version }}
+          root_file: space test.tex
+          working_directory: test/
       - name: Compile LaTeX document with pre/post compile actions
         uses: ./
         with:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,7 @@ fi
 expanded_root_file=()
 for pattern in "${root_file[@]}"; do
   # shellcheck disable=SC2206
-  expanded=($pattern)
+  IFS="" expanded=($pattern)
   expanded_root_file+=("${expanded[@]}")
 done
 root_file=("${expanded_root_file[@]}")

--- a/test/space test.tex
+++ b/test/space test.tex
@@ -1,0 +1,1 @@
+test.tex


### PR DESCRIPTION
Trying to build a tex file with a space in the filename fails.  Overriding IFS avoids word splitting during glob expansion.