### PR TITLE
fix(parameters): quote root file name to escape special characters

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
         INPUT_TEXLIVE_VERSION: ${{ inputs.texlive_version }}
         INPUT_OS: ${{ inputs.os }}
         INPUT_DOCKER_IMAGE: ${{ inputs.docker_image }}
-        INPUT_ROOT_FILE: ${{ inputs.root_file }}
+        INPUT_ROOT_FILE: "${{ inputs.root_file }}"
         INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
         INPUT_WORK_IN_ROOT_FILE_DIR: ${{ inputs.work_in_root_file_dir }}
         INPUT_CONTINUE_ON_ERROR: ${{ inputs.continue_on_error }}


### PR DESCRIPTION
My main tex file name is `Ben's Resume.tex`, currently the action errors out

```
Error:  File 'Ben' cannot be found from the directory '/home/runner/work/resume/resume'.
```

I put quotes around the variable insertion so that it properly works :

https://github.com/xu-cheng/latex-action/blob/bf9a5f2dd384b060e5809be129791fa958aa66d5/action.yml#L57

<details>
<summary>Test configuration</summary>

```yml
name: Build LaTeX document
on: [push]
jobs:
  build_latex:
    runs-on: ubuntu-latest
    steps:
      - name: Set up Git repository
        uses: actions/checkout@v4
      - name: Compile LaTeX document
        uses: xu-cheng/latex-action@v4
        with:
          latexmk_use_xelatex: true
          root_file: "Ben's Resume.tex"
      - name: Upload PDF file
        uses: actions/upload-artifact@v4
        with:
          name: PDF
          path: main.pdf
```
</details>